### PR TITLE
Remove reference to github token as an argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,3 @@ jobs:
       auto_merge: ${{ github.event_name == 'workflow_dispatch' && inputs.auto_merge || false }}
     secrets:
       rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Responding to the error here:

```
Check failure on line 18 in .github/workflows/release.yml

 
GitHub Actions
/ .github/workflows/release.yml

Invalid workflow file
error parsing called workflow
".github/workflows/release.yml"
-> "SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main" (source branch with sha:c1339f331507aadc9dcf9536d0cdf04ec2a71892)
: secret name `github_token` within `workflow_call` can not be used since it would collide with system reserved name
```
https://github.com/SOFware/pundit-plus/actions/runs/16356982069/workflow