### PR TITLE
Add OIDC role ID for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,5 @@ jobs:
       git_user_name: SOFware
       auto_merge: ${{ inputs.auto_merge || false }}
       manual_release: ${{ inputs.manual_release || false }}
-      use_trusted_publishing: false
+      use_trusted_publishing: true
+      oidc_role_id: rg_oidc_akr_7ooqz7zfa4xpqsvb42ec

--- a/bin/get_version
+++ b/bin/get_version
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/pundit/plus/version'
+
+puts Pundit::Plus::VERSION 


### PR DESCRIPTION
## Summary

This PR adds the RubyGems OIDC role ID to enable trusted publishing for pundit-plus.

## Changes

- Added `oidc_role_id: rg_oidc_akr_7ooqz7zfa4xpqsvb42ec` to the release workflow

## Dependencies

This PR depends on https://github.com/SOFware/reissue/pull/39 being merged first, which adds support for the `oidc_role_id` parameter in the shared workflow.

## What This Fixes

With this change, the release workflow will properly authenticate with RubyGems.org using OIDC trusted publishing instead of failing with "Access Denied" errors.

## Testing

Once both PRs are merged, the manual release workflow should successfully publish gems to RubyGems.org.